### PR TITLE
Review

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git -C /Users/christoph/src/github.com/devplaybooks/spark4 log --oneline)",
+      "Bash(git:*)",
+      "Bash(python -m pytest tests/ -v)"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(git -C /Users/christoph/src/github.com/devplaybooks/spark4 log --oneline)",
-      "Bash(git:*)",
-      "Bash(python -m pytest tests/ -v)"
-    ]
-  }
-}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'monthly'
+
+  - package-ecosystem: 'pip'
+    directory: '/'
+    schedule:
+      interval: 'monthly'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,33 +1,24 @@
-# This is a basic workflow to help you get started with Actions.
-# Source: https://github.com/actions/starter-workflows/blob/main/ci/blank.yml
-
 name: CI
 
 on:
   push:
   pull_request:
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
+  test:
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
 
-      # Runs a single command using the runners shell
-      - name: Run a one-line script
-        run: echo Hello, world!
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
 
-      # Runs a set of commands using the runners shell
-      - name: Run a multi-line script
-        run: |
-          echo Add other actions to build,
-          echo test, and deploy your project.
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -194,4 +194,5 @@ cython_debug/
 .cursorindexingignore
 
 # Added
+.claude/
 .virtual_documents/

--- a/.gitignore
+++ b/.gitignore
@@ -194,4 +194,4 @@ cython_debug/
 .cursorindexingignore
 
 # Added
-*.ipynb
+.virtual_documents/

--- a/README.md
+++ b/README.md
@@ -39,6 +39,40 @@ Access JupyterLab at http://localhost:8888
 
 This image includes Rust support for building high-performance extensions and working with Rust alongside PySpark. See [RUST_SUPPORT.md](RUST_SUPPORT.md) for detailed documentation.
 
+## Contributing
+
+### Prerequisites
+
+Install [asdf](https://asdf-vm.com/), then add the required plugins and install all tool versions:
+
+```shell
+asdf plugin add python
+asdf plugin add java
+asdf plugin add nodejs
+asdf plugin add scala
+asdf plugin add spark
+asdf plugin add sbt
+asdf plugin add coursier
+asdf install
+```
+
+This will provision the exact versions defined in `.tool-versions`.
+
+### Running Tests
+
+```shell
+pip install -r requirements.txt
+pytest
+```
+
+### Running Locally with Docker
+
+```shell
+docker compose up
+```
+
+Access JupyterLab at http://localhost:8888. Notebooks in `./notebooks` are mounted automatically.
+
 ## Resources
 
 - [hub.docker.com/r/jupyter/all-spark-notebook](https://hub.docker.com/r/jupyter/all-spark-notebook)

--- a/notebooks/chapter01.ipynb
+++ b/notebooks/chapter01.ipynb
@@ -1,0 +1,78 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "189b0894-306c-4e43-be49-139473227234",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+---+--------+--------------------+-----------+--------------------+\n",
+      "| id|authorId|               title|releaseDate|                link|\n",
+      "+---+--------+--------------------+-----------+--------------------+\n",
+      "|  1|       1|Fantastic Beasts ...|   11/18/16|http://amzn.to/2k...|\n",
+      "|  2|       1|Harry Potter and ...|    10/6/15|http://amzn.to/2l...|\n",
+      "|  3|       1|The Tales of Beed...|    12/4/08|http://amzn.to/2k...|\n",
+      "|  4|       1|Harry Potter and ...|    10/4/16|http://amzn.to/2k...|\n",
+      "|  5|       2|Informix 12.10 on...|    4/23/17|http://amzn.to/2i...|\n",
+      "+---+--------+--------------------+-----------+--------------------+\n",
+      "only showing top 5 rows\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pyspark.sql import SparkSession\n",
+    "import os\n",
+    "\n",
+    "current_dir = os.getcwd()\n",
+    "relative_path = \"./data/books.csv\"\n",
+    "absolute_file_path = os.path.join(current_dir, relative_path)\n",
+    "\n",
+    "# Creates a session on a local master\n",
+    "session = SparkSession.builder.appName(\"CSV to Dataset\").master(\"local[*]\").getOrCreate()\n",
+    "\n",
+    "# Reads a CSV file with header, called books.csv, stores it in a dataframe\n",
+    "df = session.read.csv(header=True, inferSchema=True, path=absolute_file_path)\n",
+    "\n",
+    "# Shows at most 5 rows from the dataframe\n",
+    "df.show(5)\n",
+    "\n",
+    "# Good to stop SparkSession at the end of the application\n",
+    "session.stop()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3ee07292-8722-4975-b46e-b5ec3c183675",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "-ra -q"
+testpaths = [
+    "tests",
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,4 @@
-[tool.pytest.ini_options]
-minversion = "6.0"
-addopts = "-ra -q"
-testpaths = [
-    "tests",
-]
+[pytest]
+minversion = 6.0
+addopts = -ra -q
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# Runtime dependencies (Spark, Jupyter, PySpark) are provided by the Docker image.
+# This file covers local development and testing only.
+pytest

--- a/src/simple_math.py
+++ b/src/simple_math.py
@@ -1,0 +1,8 @@
+def add(a, b):
+    """Return the sum of a and b."""
+    return a + b
+
+
+def subtract(a, b):
+    """Return the difference of a and b."""
+    return a - b

--- a/tests/test_simple_math.py
+++ b/tests/test_simple_math.py
@@ -1,0 +1,12 @@
+import pytest
+from src.simple_math import add, subtract
+
+def test_add():
+    assert add(2, 3) == 5
+    assert add(-1, 1) == 0
+    assert add(0, 0) == 0
+
+def test_subtract():
+    assert subtract(5, 3) == 2
+    assert subtract(0, 0) == 0
+    assert subtract(-1, -1) == 0


### PR DESCRIPTION
- CI: Replaced placeholder workflow with a real pipeline that installs dependencies and runs pytest on Python 3.12
- pytest.ini: Fixed invalid TOML syntax — converted to proper .ini format so CI can actually run
- Python package structure: Added __init__.py to src/ and tests/
- requirements.txt: Added comment clarifying that runtime dependencies (Spark, Jupyter) are provided by the Docker image and this file is for local development only
- Dependabot: Added pip ecosystem so requirements.txt dependencies are monitored alongside GitHub Actions
- .gitignore: Removed *.ipynb rule that would silently ignore new notebooks; added .virtual_documents/ (JupyterLab LSP scratch files) and .claude/ (Claude Code settings)
- README: Added Contributing section covering asdf plugin setup, asdf install, running tests locally, and the Docker workflow